### PR TITLE
Fix: translation keywords

### DIFF
--- a/src/Services/TranslateService.php
+++ b/src/Services/TranslateService.php
@@ -10,116 +10,134 @@ class TranslateService
 {
     private string $translate_from;
     private string $translate_to;
-    
+
     //setters
     public function from(string $from): TranslateService
     {
         $this->translate_from = $from;
         return $this;
     }
-    
+
     public function to(string $to): TranslateService
     {
         $this->translate_to = $to;
         return $this;
     }
-    
+
     public function translate(): void
     {
         $files = $this->getLocalLangFiles();
-        
+
         foreach ($files as $file) {
             $this->filePutContent($this->getTranslatedData($file), $file);
         }
     }
-    
+
     private function getLocalLangFiles(): array
     {
         $this->existsLocalLangDir();
         $this->existsLocalLangFiles();
-        
+
         return $this->getFiles($this->getTranslateLocalPath());
     }
-    
+
     private function filePutContent(string $translatedData, string $file): void
     {
         $folderPath = lang_path($this->translate_to);
         $fileName = pathinfo($file, PATHINFO_FILENAME) . '.php';
-        
+
         if (!File::isDirectory($folderPath)) {
             File::makeDirectory($folderPath, 0755, true);
         }
-        
+
         $filePath = $folderPath . DIRECTORY_SEPARATOR . $fileName;
         File::put($filePath, $translatedData);
     }
-    
+
     private function getTranslatedData(SplFileInfo $file): string
     {
         $translatedData = var_export($this->translateLangFiles(include $file), "false");
         return $this->addPhpSyntax($translatedData);
     }
-    
+
     private function setUpGoogleTranslate(): GoogleTranslate
     {
         $google = new GoogleTranslate();
         return $google->setSource($this->translate_from)
             ->setTarget($this->translate_to);
     }
-    
+
     private function translateLangFiles(array $content): array
     {
         $google = $this->setUpGoogleTranslate();
-        
+
         if (!empty($content)) {
             return $this->translateRecursive($content, $google);
         }
     }
-    
-    private function translateRecursive($content, $google) : array
+
+    private function translateRecursive($content, $google): array
     {
         $trans_data = [];
-        
+
         foreach ($content as $key => $value) {
             if (!is_array($value)) {
-                $trans_data[$key] = $google->translate($value);
+                /* check a keyword exists in the message */
+                if (str_contains($value, ':')) {
+                    /* add { and } around keywords to avoid translation */
+                    $modified = preg_replace_callback(
+                        '/(:\w+)/',
+                        function ($matches) {
+                            return '{' . $matches[0] . '}';
+                        },
+                        $value
+                    );
+                    /* translate text */
+                    $translated = $google->translate($modified);
+                    /* remove { and } from the translated message */
+                    $pureText = str_replace(['{', '}'], '', $translated);
+                    /* go to the next step */
+                    $trans_data[$key] = $pureText;
+                } else {
+                    $trans_data[$key] = $google->translate($value);
+                }
             } else {
                 $trans_data[$key] = $this->translateRecursive($value, $google);
             }
         }
-        
+
         return $trans_data;
     }
-    
+
     private function addPhpSyntax(string $translatedData): string
     {
         return '<?php return ' . $translatedData . ';';
     }
-    
+
     // Exceptions
     private function existsLocalLangDir(): void
     {
         $path = $this->getTranslateLocalPath();
-        
+
         throw_if(
             !File::isDirectory($path),
             ("lang folder $this->translate_from not Exist !" . PHP_EOL . '  Have you run `php artisan lang:publish` command before?')
         );
     }
-    
+
     private function existsLocalLangFiles(): void
     {
         $files = $this->getFiles($this->getTranslateLocalPath());
-        
+
         throw_if(empty($files), ("lang files in '$this->translate_from' folder not found !"));
     }
-    
+
     //helpers
     private function getFiles(string $path = null): array
     {
         return File::files($path);
     }
-    
+
     private function getTranslateLocalPath(): string
     {
         return lang_path(DIRECTORY_SEPARATOR . $this->translate_from);

--- a/src/Services/TranslateService.php
+++ b/src/Services/TranslateService.php
@@ -67,13 +67,14 @@ class TranslateService
             ->setTarget($this->translate_to);
     }
 
-    private function translateLangFiles(array $content): array
+    private function translateLangFiles(array $content): array|null
     {
         $google = $this->setUpGoogleTranslate();
 
         if (!empty($content)) {
             return $this->translateRecursive($content, $google);
         }
+        return null;
     }
 
     private function translateRecursive($content, $google): array


### PR DESCRIPTION
سلام. فایل هایی که ترجمه میشوند پیغام های پیش فرض هستند و در اغلب پیام های داخل فایل `validation.php` یک یا چند کلمه کلیدی وجود دارد که با `:` (دو نقطه) شروع میشوند تا بعدا بجای آنها نام فیلد قرار گیرد. بنابراین نباید ترجمه شوند تا بعدا سیستم بتواند آنها را پیدا و نام فیلد ها را بجای آنها قرار دهد. 
با قرار دادن کلمه ای که نمیخواهیم ترجمه شود در `{ }` میتوانیم از ترجمه ی آن جلوگیری کنیم.
من در تابع `translateRecursive` هر پیام را پیش از ترجمه مورد برسی قرار دادم که اگر شامل کلیدواژه ای است ابتدا به آنها `{ }` اضافه شود و بعد ترجمه شود و پس از ترجمه علائم `{ }` از آن پیام حذف شود.
حال این چالش مطرح میشود که نام فیلد ها که به شکل ترجمه نشده در پیام نمایشی قرار میگیرند چطور ترجمه شوند؟ برای این کار فکر میکنم با توجه به اینکه نام فیلدها دلخواه برنامه نویسان است بهتر این باشد که به لینک های زیر نگاهی کنیم...

https://laravel.com/docs/11.x/validation#customizing-the-validation-attributes
https://laravel.com/docs/11.x/validation#specifying-custom-attribute-values

باتوجه به صلاح دید خود از لینک ها در فایل `README.md` استفاده کنید.

----

ضمنا مقدار بازگشتی تابع `translateLangFiles` جلوی نام تابع آرایه تنظیم شده بود ولی یا آرایه برمیگرداند یا خالی `(void)`. من مقدار بازگشتی آن را در کنار آرایه، مقدار `null` قرار دادم که تاثیری هم روی خروجی تابع `var_export()` که در تابع `getTranslatedData` استفاده شده ندارد.