### PR TITLE
fix again: translation keywords

### DIFF
--- a/src/Services/TranslateService.php
+++ b/src/Services/TranslateService.php
@@ -82,11 +82,25 @@ class TranslateService
         $trans_data = [];
         
         foreach ($content as $key => $value) {
-            if (!is_array($value)) {
-                $trans_data[$key] = $google->translate($value);
-            } else {
+            if (is_array($value)) {
                 $trans_data[$key] = $this->translateRecursive($value, $google);
+                continue;
             }
+
+            $hasProps = str_contains($value, ':');
+            $modifiedValue = $hasProps
+                ? preg_replace_callback(
+                    '/(:\w+)/',
+                    fn($match) => '{' . $match[0] . '}',
+                    $value
+                )
+                : $value;
+
+            $translatedValue = $google->translate($modifiedValue);
+
+            $trans_data[$key] = $hasProps
+                ? str_replace(['{', '}'], '', $translatedValue)
+                : $translatedValue;
         }
         
         return $trans_data;

--- a/src/Services/TranslateService.php
+++ b/src/Services/TranslateService.php
@@ -70,10 +70,11 @@ class TranslateService
     private function translateLangFiles(array $content): array
     {
         $google = $this->setUpGoogleTranslate();
-        
-        if (!empty($content)) {
-            return $this->translateRecursive($content, $google);
-        }
+
+        if (empty($content))
+            return [];
+
+        return $this->translateRecursive($content, $google);
     }
     
     private function translateRecursive($content, $google) : array


### PR DESCRIPTION
Hi Again 😁  

سلام مهندس  @alisalehi1380 ، لطف دارید، من تا مهندس شدن راه زیاد دارم...
از توجهتون ممنونم. ✨
من نمیخواستم توی کدهاتون خیلی دست ببرم و برای همین فقط بخش مد نظر رو تغییر دادم. ولی اینطور که شما گفتید بهتره. 🚀
با drop کامیت ها مشکل داشتم، چون بعد از حذف میگفت از repo عقب تری و عجله کردم برنچ رو پاک کردم...  
برم سر اصل مطلب

تنها بخشی که یه مقدار مورد بحث هست به نظرم کد:

```php
if (str_contains($value, ':'))
```
هستش که دلیلشو بگم چرا نوشتم و بعد شما راهنماییم کنید.

فکر میکنم که تابع `preg_replace` کل حروف رشته رو مورد برسی قرار میده تا رشته هایی که مطابق با `regex` هستند رو پیدا کنه. توی فایل هایی که باید ترجمه بشن پیام های زیادی هستند که شامل کلمه ی کلیدی نیستند، و اگر ما همه رو مستقیما به `preg_replace` بدیم ، پیام های زیادی بدون اینکه شامل کلمه کلیدی باشن تمام کاراکترهاشون مورد برسی قرار میگیرن.
هرچند که `str_contains` هم رشته رو پیمایش میکنه ولی تا زمانی که اولین `:` رو پیدا کنه و پیچیدگی کمتری داره و برسی regex پیچیده تر از برسی برابری کاراکترهاست.

اینجا شاید بهتر گفته باشه:

In general, it tends to be slower and more resource-intensive than str_contains because it **involves compiling and executing a regular expression engine**, which can lead to **higher time complexity**, often **O(nm)** or worse, where n is the length of the string and m is the length of the pattern  
[source](https://aoverflow.com/question/35254/differences-between-strpos-strstr-and-preg_match/)  
[more...](https://sl.bing.net/i86k5wfu5qm)

البته اینکه برای متن بالا تابع `preg_match` رو برسی کردم بخاطر اینه که `preg_replace` ابتدا عملیاتی مشابه `preg_match` انجام میده و فقط بعد از این که پیدا شدند میاد و match ها رو عوض میکنه.

بخاطر این موضوع به نظرم برسی وجود اینکه اصلا کلمه ای هست و بعد اقدام به استخراج کردن بهتر اومد ولی سر و ته قضیه چیزی نمیشه و خب هرطور شما صلاح بدونید.
هرموقع نظرتونو بفرماید من اطاعت میکنم و کامیت میکنم. 🎈