### PR TITLE
Add OpenAI integration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /vendor
 composer.lock
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,25 +13,67 @@ Did you buy a Laravel script and it doesn't have your language in the`lang`file?
 Do you want to make your web application bilingual, but you don't know how to translate all those words?</br>
 Do you not have the possibility to use the JSON format that many Laravel language translation packages give you?
 
-
 # Installation
 ```
 composer require alisalehi/laravel-lang-files-translator
 ```
 
+After installation, publish the configuration file:
+```
+php artisan vendor:publish --tag=lang-files-translator-config
+```
+
+# Configuration
+
+The package supports two translation providers:
+- Google Translate (default)
+- OpenAI (requires API key)
+
+To use OpenAI for translations, set your API key in `.env`:
+```
+OPENAI_API_KEY=your-api-key
+```
+
 # 💎Usage
+
+The package provides a simple artisan command to translate your language files:
+
+```bash
+php artisan translate:lang {from} {to} [options]
 ```
-php artisan translate:lang {from} {to}
-```
-for example, your locale is English and you have en lang files and want to have these files to Persian(fa) lang too.
-just enough to run:
-```
+
+## Available Options
+
+### Using Google Translate (Default)
+```bash
 php artisan translate:lang en fa
 ```
-and done!
-Go to lang/fa and you will see all the translated files from the en folder.
+No configuration needed, just run the command.
 
-how to use video ⤵️
+### Using OpenAI
+First, add your OpenAI API key to `.env`:
+```
+OPENAI_API_KEY=your-api-key
+```
+
+Then run the command with OpenAI options:
+```bash
+php artisan translate:lang en fa --provider=openai --model=gpt-3.5-turbo
+```
+
+## Command Reference
+
+### Arguments:
+- `from`: Source language code (e.g., en)
+- `to`: Target language code (e.g., fa)
+
+### Options:
+- `--provider`: Translation provider (google or openai)
+- `--model`: OpenAI model name (required when using openai)
+
+After running the command, translated files will be created in the `lang/{target-language}` folder.
+
+## Demo Video ⤵️
 
 https://github.com/alisalehi1380/laravel-lang-files-translator/assets/111766206/748eaba0-29a3-4782-8505-1d8368d44ed2
 
@@ -42,14 +84,17 @@ As Einstein said, **"There's a way to do it better!"** So I welcome any change t
 
 Just open an issue or pull a request.
 
-
 ## License
 The MIT License (MIT). See **[License File](https://github.com/alisalehi1380/laravel-lang-files-translator/blob/master/LICENSE)** for more information.
 
 ## ❤️Contributing
-This project exists thanks to all the people who
-contribute. [CONTRIBUTING](https://github.com/alisalehi/laravel-lang-files-translator/graphs/contributors)
+This project exists thanks to all the people who contribute:
 
+- [Ali Salehi](https://github.com/alisalehi1380) - Original author and maintainer
+- [Amirmohammad Mokhtari](https://github.com/am-mokhtari)
+- [Navid Mirzaaghazadeh](https://github.com/mirzaaghazadeh) - Implemented OpenAI integration for natural language translation
+
+See all [contributors](https://github.com/alisalehi1380/laravel-lang-files-translator/graphs/contributors).
 
 [img-package]: https://banners.beyondco.de/laravel-lang-files-translator%20.png?theme=dark&packageManager=composer+require&packageName=alisalehi%2Flaravel-lang-files-translator&pattern=fourPointStars&style=style_1&description=Easiest+way+to+translate+lang+files&md=1&showWatermark=0&fontSize=100px&images=translate
 [ico-laravel]: https://img.shields.io/packagist/dependency-v/alisalehi/laravel-lang-files-translator/laravel/framework.svg?color=%23f13c2f

--- a/config/lang-files-translator.php
+++ b/config/lang-files-translator.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | OpenAI Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure OpenAI API settings for translation when using OpenAI provider
+    |
+    */
+    'chatgpt' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'temperature' => 0.3, // Controls translation creativity (0.0 = precise, 1.0 = creative)
+    ],
+];

--- a/src/Commands/Translate.php
+++ b/src/Commands/Translate.php
@@ -7,19 +7,36 @@ use Illuminate\Console\Command;
 
 class Translate extends Command
 {
-    protected $signature = 'translate:lang {from : translate from language} {to : translate to language}';
+    protected $signature = 'translate:lang {from : translate from language} {to : translate to language} 
+        {--provider=google : translation provider (google or openai)} 
+        {--model= : OpenAI model name (required when provider is openai)}';
     
     protected $description = 'translate lang files';
     
     public function handle(TranslateService $translateService)
     {
-        $this->info('start translation. please wait...');
+        $provider = $this->option('provider');
+        if (!in_array($provider, ['google', 'openai'])) {
+            $this->error('Invalid provider. Use either "google" or "openai"');
+            return 1;
+        }
+
+        if ($provider === 'openai' && empty($this->option('model'))) {
+            $this->error('Model name is required when using OpenAI provider');
+            return 1;
+        }
+
+        $this->info('Start translation using ' . strtoupper($provider) . ' provider...');
         $this->info(PHP_EOL . 'The speed of translation of files depends on the speed of the Internet,');
         $this->info('the number of file lines and the indentation of each key.');
         $this->info('So please be patient until the translation of the files is finished.');
         $this->info('Thankful');
         
-        $translateService->to($this->argument('to'))->from($this->argument('from'))->translate();
+        $translateService
+            ->to($this->argument('to'))
+            ->from($this->argument('from'))
+            ->withProvider($provider, $this->option('model'))
+            ->translate();
         
         $this->getOutput()->writeln(PHP_EOL . ' - Finished translation! (go to lang/' . $this->argument('to') . ' folder) ');
         

--- a/src/Contracts/TranslatorInterface.php
+++ b/src/Contracts/TranslatorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Alisalehi\LaravelLangFilesTranslator\Contracts;
+
+interface TranslatorInterface
+{
+    public function setSource(string $source): self;
+    public function setTarget(string $target): self;
+    public function translate(string $text): string;
+}

--- a/src/LangFilesTranslatorServiceProvider.php
+++ b/src/LangFilesTranslatorServiceProvider.php
@@ -13,13 +13,20 @@ class LangFilesTranslatorServiceProvider extends ServiceProvider
     
     public function register(): void
     {
-    
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/lang-files-translator.php',
+            'lang-files-translator'
+        );
     }
     
     public function boot(): void
     {
         if ($this->app->runningInConsole()) {
             $this->commands(self::$commandNames);
+            
+            $this->publishes([
+                __DIR__ . '/../config/lang-files-translator.php' => config_path('lang-files-translator.php'),
+            ], 'lang-files-translator-config');
         }
     }
 }

--- a/src/Services/TranslatorFactory.php
+++ b/src/Services/TranslatorFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Alisalehi\LaravelLangFilesTranslator\Services;
+
+use Alisalehi\LaravelLangFilesTranslator\Contracts\TranslatorInterface;
+use Alisalehi\LaravelLangFilesTranslator\Services\Translators\ChatGPTTranslator;
+use Alisalehi\LaravelLangFilesTranslator\Services\Translators\GoogleTranslator;
+
+class TranslatorFactory
+{
+    public static function create(string $provider = 'google', ?string $model = null): TranslatorInterface
+    {
+        if ($provider === 'openai') {
+            if (empty($model)) {
+                throw new \InvalidArgumentException('Model parameter is required for OpenAI provider');
+            }
+            $translator = new ChatGPTTranslator();
+            $translator->setModel($model);
+            return $translator;
+        }
+
+        if ($provider === 'google') {
+            return new GoogleTranslator();
+        }
+
+        throw new \InvalidArgumentException("Unsupported translator provider: {$provider}");
+    }
+}

--- a/src/Services/Translators/ChatGPTTranslator.php
+++ b/src/Services/Translators/ChatGPTTranslator.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Alisalehi\LaravelLangFilesTranslator\Services\Translators;
+
+use Alisalehi\LaravelLangFilesTranslator\Contracts\TranslatorInterface;
+use Illuminate\Support\Facades\Http;
+
+class ChatGPTTranslator implements TranslatorInterface
+{
+    private string $source;
+    private string $target;
+    private string $apiKey;
+    private string $model;
+    private float $temperature;
+
+    public function __construct()
+    {
+        $this->apiKey = config('lang-files-translator.chatgpt.api_key');
+        $this->temperature = config('lang-files-translator.chatgpt.temperature', 0.3);
+
+        if (empty($this->apiKey)) {
+            throw new \RuntimeException('OpenAI API key is not configured. Set OPENAI_API_KEY in your .env file.');
+        }
+    }
+
+    public function setModel(string $model): self
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function setSource(string $source): TranslatorInterface
+    {
+        $this->source = $source;
+        return $this;
+    }
+
+    public function setTarget(string $target): TranslatorInterface
+    {
+        $this->target = $target;
+        return $this;
+    }
+
+    public function translate(string $text): string
+    {
+        $response = Http::withHeaders([
+            'Authorization' => 'Bearer ' . $this->apiKey,
+            'Content-Type' => 'application/json',
+        ])->post('https://api.openai.com/v1/chat/completions', [
+            'model' => $this->model,
+            'messages' => [
+                [
+                    'role' => 'system',
+                    'content' => "You are a professional translator. Translate from {$this->source} to {$this->target}. Maintain any variables or placeholders in the text. Only return the translated text without explanations or additional context.",
+                ],
+                [
+                    'role' => 'user',
+                    'content' => $text,
+                ],
+            ],
+            'temperature' => $this->temperature,
+        ]);
+
+        if (!$response->successful()) {
+            throw new \RuntimeException('ChatGPT API request failed: ' . $response->body());
+        }
+
+        return trim($response->json('choices.0.message.content'));
+    }
+}

--- a/src/Services/Translators/GoogleTranslator.php
+++ b/src/Services/Translators/GoogleTranslator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Alisalehi\LaravelLangFilesTranslator\Services\Translators;
+
+use Alisalehi\LaravelLangFilesTranslator\Contracts\TranslatorInterface;
+use Stichoza\GoogleTranslate\GoogleTranslate;
+
+class GoogleTranslator implements TranslatorInterface
+{
+    private GoogleTranslate $translator;
+
+    public function __construct()
+    {
+        $this->translator = new GoogleTranslate();
+    }
+
+    public function setSource(string $source): TranslatorInterface
+    {
+        $this->translator->setSource($source);
+        return $this;
+    }
+
+    public function setTarget(string $target): TranslatorInterface
+    {
+        $this->translator->setTarget($target);
+        return $this;
+    }
+
+    public function translate(string $text): string
+    {
+        return $this->translator->translate($text);
+    }
+}


### PR DESCRIPTION
This PR adds OpenAI's language models as an alternative translation provider alongside the existing Google Translate functionality. 

### Key changes:

**Features:**
- Add command-line provider selection (--provider option)
- Add OpenAI model selection (--model option)
- Add ChatGPT translation service with customizable models
- Maintain backward compatibility with Google Translate

**Technical Changes:**
- Introduce TranslatorInterface for consistent translator implementations
- Add TranslatorFactory for provider instantiation
- Add configuration for OpenAI API settings
- Update command to handle provider and model selection
- Improve error handling for invalid configurations
